### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - &checkout
         name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           show-progress: false
 
@@ -80,7 +80,7 @@ jobs:
       fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           show-progress: false
           fetch-depth: 0
@@ -94,7 +94,7 @@ jobs:
           path: |
             ~/.cargo
             ./target
-          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-${{ env.GITHUB_JOB }}
+          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-${{ github.job }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-
             ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-
@@ -143,7 +143,15 @@ jobs:
       - name: Install cocogitto to get the next version number
         shell: bash
         run: |
-          cargo binstall --github-token ${{ secrets.GITHUB_TOKEN }} --no-confirm cocogitto --pkg-url "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.tar.gz" --bin-dir "{ target }/{ bin }{ binary-ext }" --target x86_64-unknown-linux-musl --pkg-fmt tgz --bin cog --strategies crate-meta-data
+          cargo binstall \
+            --github-token ${{ secrets.GITHUB_TOKEN }} \
+            --no-confirm cocogitto \
+            --pkg-url "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.tar.gz" \
+            --bin-dir "{ target }/{ bin }{ binary-ext }" \
+            --target x86_64-unknown-linux-musl \
+            --pkg-fmt tgz \
+            --bin cog \
+            --strategies crate-meta-data
 
       - name: Calculate next version
         shell: bash
@@ -343,16 +351,14 @@ jobs:
         with:
           args: ${{ env.CARGO_FEATURES }} --all-targets --locked --workspace --verbose
 
+  # this name is also used in `publish-crate-after-release.yml`
   docker-build:
-    name: Build Docker container on ${{ matrix.runs-on }} for ${{ matrix.platform }}
+    name: Build Docker container on ${{ matrix.runs-on }}
     strategy:
       matrix:
         runs-on:
           - "ubuntu-latest"
           - "ubuntu-24.04-arm"
-        platform:
-          - "amd64"
-          - "arm64"
     outputs:
       application_name: ${{ steps.variables.outputs.application_name }}
       description: ${{ steps.variables.outputs.description }}
@@ -426,10 +432,6 @@ jobs:
           unique_tag=pr-${{ github.event.pull_request.base.sha }}-${{ github.event.pull_request.head.sha }}
           echo "unique_tag=${unique_tag}" >> ${GITHUB_OUTPUT}
 
-          # but we're only building 1 arch here, so we need to identify that container (we'll merge them later)
-          unique_tag_arch=${unique_tag}-${{ matrix.platform }}
-          echo "unique_tag_arch=${unique_tag_arch}" >> ${GITHUB_OUTPUT}
-
           # The application name, used in the Dockerfile
           application_name=${{ env.IMAGE_NAME }}
           # split at the last / and keep that (kristof-mattei/repo-name -> repo-name)
@@ -464,13 +466,13 @@ jobs:
         id: meta
         with:
           labels: |
-            org.opencontainers.image.description=${{ steps.variables.outputs.description }} (${{ matrix.platform }})
+            org.opencontainers.image.description=${{ steps.variables.outputs.description }}
             org.opencontainers.image.revision=${{ github.event.pull_request.base.sha }}-${{ github.event.pull_request.head.sha }}
             org.opencontainers.image.source=${{ github.event.pull_request.html_url }}
             org.opencontainers.image.version=pr-${{ github.event.number }}
           images: ${{ steps.variables.outputs.full_image_name_local_registry }}
           tags: |
-            type=raw,value=${{ steps.variables.outputs.unique_tag_arch }}
+            type=raw,value=${{ steps.variables.outputs.unique_tag }}
 
       - name: Log into registry ${{ steps.variables.outputs.registry }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
@@ -493,11 +495,11 @@ jobs:
           context: .
           # this container is THE PR's artifact, and we will re-tag it
           # once the PR has been accepted
-          cache-from: type=registry,ref=${{ steps.variables.outputs.full_image_name_remote_registry }}:buildcache-${{ runner.arch }}-${{ steps.variables.outputs.application_name }}-${{ matrix.platform }}
-          cache-to: type=registry,ref=${{ steps.variables.outputs.full_image_name_remote_registry }}:buildcache-${{ runner.arch }}-${{ steps.variables.outputs.application_name }}-${{ matrix.platform }},mode=max
+          cache-from: type=registry,ref=${{ steps.variables.outputs.full_image_name_remote_registry }}:buildcache-${{ runner.arch }}-${{ steps.variables.outputs.application_name }}
+          cache-to: type=registry,ref=${{ steps.variables.outputs.full_image_name_remote_registry }}:buildcache-${{ runner.arch }}-${{ steps.variables.outputs.application_name }},mode=max
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=oci,dest=/tmp/${{ steps.variables.outputs.unique_tag_arch }}.tar
-          platforms: linux/${{ matrix.platform }}
+          outputs: type=oci,dest=/tmp/${{ steps.variables.outputs.unique_tag }}.tar
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Upload artifact
@@ -506,8 +508,8 @@ jobs:
           matrix.runs-on == 'ubuntu-latest'
         with:
           if-no-files-found: error
-          name: container-${{ steps.variables.outputs.application_name }}-${{ matrix.platform }}
-          path: /tmp/${{ steps.variables.outputs.unique_tag_arch }}.tar
+          name: container-${{ steps.variables.outputs.application_name }}
+          path: /tmp/${{ steps.variables.outputs.unique_tag }}.tar
           retention-days: 1
 
   docker-publish:
@@ -565,26 +567,20 @@ jobs:
             type=ref,event=pr,suffix=-latest
 
       - name: Download artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         id: artifact
         with:
-          merge-multiple: true
           path: /tmp/container/
-          pattern: container-${{ needs.docker-build.outputs.application_name }}-*
+          name: container-${{ needs.docker-build.outputs.application_name }}
 
-      - name: Load individual platform images from artifacts & push to registry
+      - name: Load image from artifacts & push to registry
         shell: bash
         working-directory: ${{ steps.artifact.outputs.download-path }}
         run: |
-          docker load --input ./${{ needs.docker-build.outputs.unique_tag }}-amd64.tar
-          echo "Pushing amd64:"
-          docker push ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}-amd64
+          docker load --input ./${{ needs.docker-build.outputs.unique_tag }}.tar
+          docker push ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}
 
-          docker load --input ./${{ needs.docker-build.outputs.unique_tag }}-arm64.tar
-          echo "Pushing arm64:"
-          docker push ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}-arm64
-
-      - name: Create multiplatform image
+      - name: Create image in final destination
         shell: bash
         run: |
           new_tags=()
@@ -599,10 +595,9 @@ jobs:
             new_labels+=("index:${label}")
           done <<< "${{ steps.meta.outputs.labels }}"
 
-          # merge the amd64 and arm64 containers in a new multiplatform one
+          # merge labels & annotations
           docker buildx imagetools create "${new_tags[@]}" "${new_labels[@]}" \
-            ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}-amd64 \
-            ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}-arm64
+            ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}
 
           for new_tag in $(echo "${{ join(steps.meta.outputs.tags, ' ') }}"); do
             echo "${new_tag}:"
@@ -611,9 +606,9 @@ jobs:
             echo ""
           done
 
-      - name: Get digest of multiplatform image in our local registry
+      - name: Get digest of image in our local registry
         shell: bash
-        id: multiplatform_image
+        id: local_image
         run: |
           digest=$(docker buildx imagetools inspect ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }} --format "{{json .}}" | jq --raw-output ".manifest.digest")
 
@@ -631,11 +626,11 @@ jobs:
       # since we deal with tags (mutable), and the way to get a digest is to use the tag, I prefer
       # sourcing the digest from the local registry we just spun up (trusted)
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
         id: attestation
         with:
           subject-name: ${{ needs.docker-build.outputs.full_image_name_remote_registry }}
-          subject-digest: ${{ steps.multiplatform_image.outputs.digest }}
+          subject-digest: ${{ steps.local_image.outputs.digest }}
           push-to-registry: true
 
   all-done:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           show-progress: false
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           show-progress: false
 

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           show-progress: false
           fetch-depth: 0

--- a/.github/workflows/publish-crate-after-release.yml
+++ b/.github/workflows/publish-crate-after-release.yml
@@ -43,7 +43,7 @@ jobs:
       fromJSON(needs.repo-has-crate.outputs.has_crate) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           show-progress: false
 
@@ -55,7 +55,8 @@ jobs:
           path: |
             ~/.cargo
             ./target
-          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-test
+          # notice the `docker-build` suffix, so that it will use the same cache
+          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-docker-build
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-
             ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           show-progress: false

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -57,7 +57,7 @@ jobs:
       fromJSON(needs.repo-has-container.outputs.has_container) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           show-progress: false
           fetch-depth: 2

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           show-progress: false
 

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -30,7 +30,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           show-progress: false

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".vscode/rust-prettifier-for-lldb"]
-	path = .vscode/rust-prettifier-for-lldb
-	url = https://github.com/cmrschwarz/rust-prettifier-for-lldb

--- a/.vscode/rust_prettifier_for_lldb.py
+++ b/.vscode/rust_prettifier_for_lldb.py
@@ -1,1 +1,0 @@
-./rust-prettifier-for-lldb/rust_prettifier_for_lldb.py

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,6 @@
 {
     "debug.internalConsoleOptions": "neverOpen",
     "lldb.launch.expressions": "simple",
-    "lldb.launch.preRunCommands": [
-        "command script import ${workspaceFolder}/.vscode/rust_prettifier_for_lldb.py"
-    ],
     "lldb.launch.terminal": "integrated",
     "prettier.configPath": "./prettier.config.mjs",
     "rust-analyzer.cargo.extraEnv": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "packageManager": "pnpm@10.15.0",
   "engines": {
-    "node": "22.19.0",
+    "node": "24.7.0",
     "pnpm": "10.15.0"
   },
   "scripts": {


### PR DESCRIPTION
- **chore(deps): lock file maintenance**
- **fix: set full version**
- **chore: remove lldb-prettifier built as part of repo, use shared config**
- **chore: fmt**
- **chore(deps): update rui314/setup-mold digest to 725a879**
- **chore(deps): update rust:1.89.0-trixie docker digest to 26318ae**
- **fix: build multi-platform docker images**
- **chore(deps): update returntocorp/semgrep docker tag to v1.134.0**
- **feat: write output to per-target folder, otherwise caches overwrite each other causing recompilation in the install step**
- **fix: pre-cache**
- **chore(deps): update node.js to v22.19.0**
- **chore(deps): update actions/attest-build-provenance action to v3**
- **chore: remove submodule folder**
